### PR TITLE
Implement persistent sessions

### DIFF
--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -38,7 +38,11 @@ export class LoginPage implements OnInit {
     private router: Router
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    if (this.sessionService.isLoggedIn()) {
+      this.router.navigate(['/listas']);
+    }
+  }
 
   email = environment.sacEmail;
   user = '';

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,13 +1,27 @@
 import { Injectable } from '@angular/core';
 
+const STORAGE_KEY = 'sessionUserData';
+
 @Injectable({
   providedIn: 'root',
 })
 export class SessionService {
   private userData: any = null;
 
+  constructor() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        this.userData = JSON.parse(stored);
+      } catch {
+        this.userData = null;
+      }
+    }
+  }
+
   setUserData(data: any) {
     this.userData = data;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
   }
 
   getUserData() {
@@ -27,6 +41,7 @@ export class SessionService {
 
   clearUserData() {
     this.userData = null;
+    localStorage.removeItem(STORAGE_KEY);
   }
 
   isLoggedIn(): boolean {


### PR DESCRIPTION
## Summary
- persist user session data in `SessionService`
- auto-redirect logged-in users away from the login page

## Testing
- `npm run lint --silent` *(fails: ng not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604beaddac832581e3318356065ec2