### PR TITLE
Fix incorrect API path in categorias service

### DIFF
--- a/src/app/services/categorias.service.ts
+++ b/src/app/services/categorias.service.ts
@@ -43,7 +43,7 @@ export class CategoriasService {
   }
 
   getCategorias( usuario: number ): Observable <any> {
-    const url = 'https://bpm.desarrollogt.net/ROOT7API/API_util.php';
+    const url = 'https://bpm.desarrollogt.net/ROOT/API/API_util.php';
     const params = { request: 'categorias', usuario: usuario.toString() } ;
     return this.httpClient.get<any>( url, {params });
   }


### PR DESCRIPTION
## Summary
- correct the URL for categorias API call

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604b050594832587c1a470f7c077cb