### PR TITLE
Add filterListas unit tests

### DIFF
--- a/src/app/pages/listas/listas.page.spec.ts
+++ b/src/app/pages/listas/listas.page.spec.ts
@@ -14,4 +14,42 @@ describe('ListasPage', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('filterListas', () => {
+    beforeEach(() => {
+      component.listas = [
+        { nombre: 'Lista Uno', categoria: 'Categoria A', estado: 'Activa' },
+        { nombre: 'Segunda Lista', categoria: 'Categoria B', estado: 'Inactiva' },
+        { nombre: 'Tercera', categoria: 'Otra', estado: 'Activa' },
+      ];
+    });
+
+    it('should return all items when searchText is empty', () => {
+      component.searchText = '';
+      component.filterListas();
+      expect(component.filteredListas.length).toBe(3);
+    });
+
+    it('should filter by name', () => {
+      component.searchText = 'segunda';
+      component.filterListas();
+      expect(component.filteredListas).toEqual([
+        { nombre: 'Segunda Lista', categoria: 'Categoria B', estado: 'Inactiva' },
+      ]);
+    });
+
+    it('should filter by category', () => {
+      component.searchText = 'otra';
+      component.filterListas();
+      expect(component.filteredListas).toEqual([
+        { nombre: 'Tercera', categoria: 'Otra', estado: 'Activa' },
+      ]);
+    });
+
+    it('should filter by state', () => {
+      component.searchText = 'activa';
+      component.filterListas();
+      expect(component.filteredListas.length).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- expand `src/app/pages/listas/listas.page.spec.ts` with tests for `filterListas`

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_686099054ca8832599cfd7ed66f4cfae